### PR TITLE
Suggested updates

### DIFF
--- a/src/Serilog.Sinks.Amazon.Kinesis/Firehose/Sinks/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Firehose/Sinks/HttpLogShipper.cs
@@ -65,9 +65,9 @@ namespace Serilog.Sinks.Amazon.Kinesis.Firehose.Sinks
             };
 
             SelfLog.WriteLine("Writing {0} records to firehose", records.Count);
-            var putRecordBatchTask = Task.Run(async () => await _kinesisFirehoseClient.PutRecordBatchAsync(request));
+            var putRecordBatchTask = _kinesisFirehoseClient.PutRecordBatchAsync(request);
 
-            successful = putRecordBatchTask.Result.FailedPutCount == 0;
+            successful = putRecordBatchTask.GetAwaiter().GetResult().FailedPutCount == 0;
             return putRecordBatchTask.Result;
         }
 

--- a/src/Serilog.Sinks.Amazon.Kinesis/Firehose/Sinks/KinesisFirehoseSink.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Firehose/Sinks/KinesisFirehoseSink.cs
@@ -15,6 +15,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Amazon.KinesisFirehose;
 using Amazon.KinesisFirehose.Model;
 using Serilog.Events;
@@ -63,7 +64,7 @@ namespace Serilog.Sinks.Amazon.Kinesis.Firehose.Sinks
         /// Emit a batch of log events, running to completion asynchronously.
         /// </summary>
         /// <param name="events">The events to be logged to Kinesis Firehose</param>
-        protected override async void EmitBatch(IEnumerable<LogEvent> events)
+        protected override Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
             var request = new PutRecordBatchRequest
             {
@@ -85,7 +86,7 @@ namespace Serilog.Sinks.Amazon.Kinesis.Firehose.Sinks
                 request.Records.Add(entry);
             }
 
-            var response = _state.KinesisFirehoseClient.PutRecordBatchAsync(request).Result;
+            return _state.KinesisFirehoseClient.PutRecordBatchAsync(request);
         }
 
 

--- a/src/Serilog.Sinks.Amazon.Kinesis/Firehose/Sinks/KinesisFirehoseSink.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Firehose/Sinks/KinesisFirehoseSink.cs
@@ -45,22 +45,6 @@ namespace Serilog.Sinks.Amazon.Kinesis.Firehose.Sinks
         }
 
         /// <summary>
-        /// Free resources held by the sink.
-        /// </summary>
-        /// <param name="disposing">If true, called because the object is being disposed; if false,
-        /// the object is being disposed from the finalizer.</param>
-        protected override void Dispose(bool disposing)
-        {
-            // First flush the buffer
-            base.Dispose(disposing);
-
-            if (disposing)
-            {
-                _state.KinesisFirehoseClient.Dispose();
-            }
-        }
-
-        /// <summary>
         /// Emit a batch of log events, running to completion asynchronously.
         /// </summary>
         /// <param name="events">The events to be logged to Kinesis Firehose</param>

--- a/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/HttpLogShipper.cs
@@ -67,9 +67,9 @@ namespace Serilog.Sinks.Amazon.Kinesis.Stream.Sinks
             };
 
             SelfLog.WriteLine("Writing {0} records to kinesis", records.Count);
-            var putRecordBatchTask = Task.Run(async () => await _kinesisClient.PutRecordsAsync(request));
+            var putRecordBatchTask = _kinesisClient.PutRecordsAsync(request);
 
-            successful = putRecordBatchTask.Result.FailedRecordCount == 0;
+            successful = putRecordBatchTask.GetAwaiter().GetResult().FailedRecordCount == 0;
             return putRecordBatchTask.Result;
         }
 

--- a/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/KinesisApi.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/KinesisApi.cs
@@ -139,8 +139,8 @@ namespace Serilog.Sinks.Amazon.Kinesis.Stream.Sinks
             var request = new CreateStreamRequest { StreamName = streamName, ShardCount = shardCount };
             try
             {
-                var createStreamResponse = Task.Run(async () => await kinesisClient.CreateStreamAsync(request));
-                return createStreamResponse.Result;
+                var createStreamResponse = kinesisClient.CreateStreamAsync(request);
+                return createStreamResponse.GetAwaiter().GetResult();
             }
             catch (AmazonServiceException e)
             {
@@ -156,8 +156,8 @@ namespace Serilog.Sinks.Amazon.Kinesis.Stream.Sinks
             var request = new DescribeStreamRequest { StreamName = streamName };
             try
             {
-                var describeStreamTask = Task.Run(async () => await kinesisClient.DescribeStreamAsync(request));
-                return describeStreamTask.Result;
+                var describeStreamTask = kinesisClient.DescribeStreamAsync(request);
+                return describeStreamTask.GetAwaiter().GetResult();
             }
             catch (ResourceNotFoundException)
             {

--- a/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/KinesisSink.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/KinesisSink.cs
@@ -71,7 +71,7 @@ namespace Serilog.Sinks.Amazon.Kinesis.Stream.Sinks
         /// Emit a batch of log events, running to completion asynchronously.
         /// </summary>
         /// <param name="events">The events to be logged to Kinesis</param>
-        protected override void EmitBatch(IEnumerable<LogEvent> events)
+        protected override Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
             var request = new PutRecordsRequest
             {
@@ -93,8 +93,7 @@ namespace Serilog.Sinks.Amazon.Kinesis.Stream.Sinks
 
                 request.Records.Add(entry);
             }
-            var task = Task.Run<PutRecordsResponse>(async () => await _state.KinesisClient.PutRecordsAsync(request));
-            task.Wait();
+            return _state.KinesisClient.PutRecordsAsync(request);
         }
 
 

--- a/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/KinesisSink.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/KinesisSink.cs
@@ -50,23 +50,6 @@ namespace Serilog.Sinks.Amazon.Kinesis.Stream.Sinks
             Dispose(true);
         }
 
-
-        /// <summary>
-        /// Free resources held by the sink.
-        /// </summary>
-        /// <param name="disposing">If true, called because the object is being disposed; if false, 
-        /// the object is being disposed from the finalizer.</param>
-        protected override void Dispose(bool disposing)
-        {
-            // First flush the buffer
-            base.Dispose(disposing);
-
-            if (disposing)
-            {
-                _state.KinesisClient.Dispose();
-            }
-        }
-
         /// <summary>
         /// Emit a batch of log events, running to completion asynchronously.
         /// </summary>


### PR DESCRIPTION
Couple suggestions:
- Switch from task `.Result` to `.GetAwaiter().GetResult()` pattern for improved exception transparency.
- Switch from `EmitBatch` to `EmitBatchAsync` to help synchronization issues in Lambda clients.
- Remove Kinesis client disposal for those of us who are control freaks about object scoping. (Disposing a logger was disposing the client which was then unavailable for re-use.)