### PR TITLE
Fixing the build. AssemblyInfo was missing therefor internal classes …

### DIFF
--- a/src/Serilog.Sinks.Amazon.Kinesis/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Properties/AssemblyInfo.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Serilog.Sinks.Amazon.Kinesis.Tests, PublicKey=00240000048000009400000006020000" +
+                                                                    "00240000525341310004000001000100" +
+                                                                    "FB8D13FD344A1C6FE0FE83EF33C1080B" +
+                                                                    "F30690765BC6EB0DF26EBFDF8F21670C" +
+                                                                    "64265B30DB09F73A0DEA5B3DB4C9D18D" +
+                                                                    "BF6D5A25AF5CE9016F281014D79DC3B4" +
+                                                                    "201AC646C451830FC7E61A2DFD633D34" +
+                                                                    "C39F87B81894191652DF5AC63CC40C77" +
+                                                                    "F3542F702BDA692E6E8A9158353DF189" +
+                                                                    "007A49DA0F3CFD55EB250066B19485EC")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=00240000048000009400000006020000002" +
+                                                                    "40000525341310004000001000100c547ca" +
+                                                                    "c37abd99c8db225ef2f6c8a3602f3b3606c" +
+                                                                    "c9891605d02baa56104f4cfc0734aa39b93" +
+                                                                    "bf7852f7d9266654753cc297e7d2edfe0ba" +
+                                                                    "c1cdcf9f717241550e0a7b191195b7667bb" +
+                                                                    "4f64bcb8e2121380fd1d9d46ad2d92d2d15" +
+                                                                    "605093924cceaf74c4861eff62abf69b929" +
+                                                                    "1ed0a340e113be11e6a7d3113e92484cf70" +
+                                                                    "45cc7")]

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
@@ -70,9 +70,8 @@
       <HintPath>..\..\packages\Serilog.Sinks.Trace.2.1.0\lib\net45\Serilog.Sinks.Trace.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Shouldly, Version=2.7.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Shouldly.2.7.0\lib\net40\Shouldly.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Shouldly, Version=2.8.3.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Shouldly.2.8.3\lib\net40\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
@@ -10,5 +10,6 @@
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="Serilog" version="2.6.0" targetFramework="net45" />
   <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net45" />
+  <package id="Shouldly" version="2.8.3" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
…couldn't be tested.

 Adding missing packages.

@troylar Why is the .vs dir added? Should it be included?