### PR TITLE
Fixing appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ build_script:
 - ps: >-
     $version = "2.2"
     set VisualStudioVersion=15.0
-	set VSINSTALLDIR=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\		
+	
     ./Build.ps1 -majorMinor "$version" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:
 - path: Serilog.*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ build_script:
 - ps: >-
     $version = "2.2"
     set VisualStudioVersion=15.0
-	
+    set VSINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise"
     ./Build.ps1 -majorMinor "$version" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:
 - path: Serilog.*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{build}'
 build_script:
 - ps: >-
     $version = "2.2"
-    $env:VisualStudioVersion=15.0
+    $env:VisualStudioVersion="15.0"
     $env:VSINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise"
     ./Build.ps1 -majorMinor "$version" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@ version: '{build}'
 build_script:
 - ps: >-
     $version = "2.2"
-    set VisualStudioVersion=15.0
-    set VSINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise"
+    $env:VisualStudioVersion=15.0
+    $env:VSINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise"
     ./Build.ps1 -majorMinor "$version" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:
 - path: Serilog.*.nupkg
@@ -12,5 +12,4 @@ deploy:
   api_key:
     secure: nvZ/z+pMS91b3kG4DgfES5AcmwwGoBYQxr9kp4XiJHj25SAlgdIxFx++1N0lFH2x--toegevoegd
   on:
-    branch: master
-    
+    branch: master    

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,6 @@ build_script:
     $version = "2.2"
 
     $env:VisualStudioVersion = 15.0
-
-    $env:VSINSTALLDIR=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
     
     ./Build.ps1 -majorMinor "$version" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ environment:
 build_script:
 - ps: >-
     $version = "2.2"
+
+    $env:VisualStudioVersion = 15.0
+
+    $env:VSINSTALLDIR=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
     
     ./Build.ps1 -majorMinor "$version" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 version: '{build}'
+environment:
+  VisualStudioVersion: 15.0
 build_script:
 - ps: >-
     $version = "2.2"
-    $env:VisualStudioVersion="15.0"
-    $env:VSINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise"
     ./Build.ps1 -majorMinor "$version" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:
 - path: Serilog.*.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,9 @@ environment:
 build_script:
 - ps: >-
     $version = "2.2"
+    
     ./Build.ps1 -majorMinor "$version" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
 artifacts:
 - path: Serilog.*.nupkg
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,14 +2,15 @@ version: '{build}'
 build_script:
 - ps: >-
     $version = "2.2"
-    
+    set VisualStudioVersion=15.0
+	set VSINSTALLDIR=C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\		
     ./Build.ps1 -majorMinor "$version" -patch "$env:APPVEYOR_BUILD_VERSION" -customLogger "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 artifacts:
 - path: Serilog.*.nupkg
 deploy:
 - provider: NuGet
   api_key:
-    secure: nvZ/z+pMS91b3kG4DgfES5AcmwwGoBYQxr9kp4XiJHj25SAlgdIxFx++1N0lFH2x
+    secure: nvZ/z+pMS91b3kG4DgfES5AcmwwGoBYQxr9kp4XiJHj25SAlgdIxFx++1N0lFH2x--toegevoegd
   on:
     branch: master
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 version: '{build}'
+image: Visual Studio 2017
 environment:
   VisualStudioVersion: 15.0
 build_script:

--- a/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
@@ -9,7 +9,7 @@
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>Serilog.Sinks.AmazonKinesis</AssemblyName>
+    <AssemblyName>Serilog.Sinks.Amazon.Kinesis</AssemblyName>
     <AssemblyOriginatorKeyFile>assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>

--- a/src/Serilog.Sinks.AmazonKinesis.nuspec
+++ b/src/Serilog.Sinks.AmazonKinesis.nuspec
@@ -22,8 +22,11 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.dll" target="lib\net45" />
-    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.pdb" target="lib\net45" />
-    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.xml" target="lib\net45" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\net45\Serilog.Sinks.Amazon.Kinesis.dll" target="lib\net45" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\net45\Serilog.Sinks.Amazon.Kinesis.pdb" target="lib\net45" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\net45\Serilog.Sinks.Amazon.Kinesis.xml" target="lib\net45" />
+	<file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\netstandard2.0\Serilog.Sinks.Amazon.Kinesis.dll" target="lib\netstandard2.0" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\netstandard2.0\Serilog.Sinks.Amazon.Kinesis.pdb" target="lib\netstandard2.0" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\netstandard2.0\Serilog.Sinks.Amazon.Kinesis.xml" target="lib\netstandard2.0" />
   </files>
 </package>


### PR DESCRIPTION
Adding more fixes to make sure the ci is correctly working. Changed the assembly name back to 
`Serilog.Sinks.Amazon.Kinesis</AssemblyName>`

Fixed nuspec to make sure the libs are correctly targeted and `build.ps1` is able to correctly build. 
Fixe appveyor.yml to make sure correct image is going to chosen. (VS2017)

@troylar Perhaps also targeting for .net standard 1.6.0?
@troylar If you're merging can you squash the commits. 
